### PR TITLE
Ability to configure ENPreferencesStore via .Net configuration

### DIFF
--- a/src/Evernote-SDK-Windows.sln
+++ b/src/Evernote-SDK-Windows.sln
@@ -1,11 +1,13 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.30723.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.22823.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EvernoteSDK", "EvernoteSDK\EvernoteSDK.csproj", "{EFB2706A-EE60-4B33-ABD4-695B509F277B}"
 EndProject
 Project("{54435603-DBB4-11D2-8724-00A0C9A8B90C}") = "EvernoteSDK_COMSetup", "EvernoteSDK_COMSetup\EvernoteSDK_COMSetup.vdproj", "{1AB456C0-75F7-4606-A6C3-258F088D6B07}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EvernoteSDK.Tests", "EvernoteSDK.Tests\EvernoteSDK.Tests.csproj", "{86794611-FE20-4267-95E7-4EF76FBB51FC}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -21,6 +23,10 @@ Global
 		{1AB456C0-75F7-4606-A6C3-258F088D6B07}.Debug|Any CPU.Build.0 = Debug
 		{1AB456C0-75F7-4606-A6C3-258F088D6B07}.Release|Any CPU.ActiveCfg = Release
 		{1AB456C0-75F7-4606-A6C3-258F088D6B07}.Release|Any CPU.Build.0 = Release
+		{86794611-FE20-4267-95E7-4EF76FBB51FC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{86794611-FE20-4267-95E7-4EF76FBB51FC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{86794611-FE20-4267-95E7-4EF76FBB51FC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{86794611-FE20-4267-95E7-4EF76FBB51FC}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/EvernoteSDK.Tests/App.config
+++ b/src/EvernoteSDK.Tests/App.config
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <!-- Uncomment below section to test memory based preference store. The section tag name must be <EvernoteSDK>-->
+  <!--<configSections>
+    <section name="EvernoteSDK" type="EvernoteSDK.Configuration.ENSDKConfiguration, EvernoteSDK"/>
+  </configSections>
+  <EvernoteSDK preferencesStoreType="EvernoteSDK.Tests.TestMemoryBasedENPreferenceStore, EvernoteSDK.Tests"></EvernoteSDK>-->
+</configuration>

--- a/src/EvernoteSDK.Tests/ENSession_DeleteNote.cs
+++ b/src/EvernoteSDK.Tests/ENSession_DeleteNote.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace EvernoteSDK.Tests
+{
+    [TestClass]
+    public class ENSession_DeleteNote
+    {
+        [TestInitialize]
+        public void Initialize()
+        {
+            TestUtils.AuthenticateToEverNote();
+        }
+        [TestMethod]
+        public void WhenNoteContainsHtml_ShoudBeAbleToDelete()
+        {
+            // Create a new note (in the user's default notebook) with some HTML content.
+            ENNote myFancyNote = new ENNote();
+            myFancyNote.Title = "My fancy note to delete";
+            myFancyNote.Content = ENNoteContent.NoteContentWithSanitizedHTML("<p>Hello, world - <i>this</i> is a <b>fancy</b> note - and here is a table:</p><br /> <br/><table border=\"1\" cellpadding=\"2\" cellspacing=\"0\" width=\"100%\"><tr><td>Red</td><td>Green</td></tr><tr><td>Blue</td><td>Yellow</td></tr></table>");
+            ENNoteRef myFancyNoteRef = ENSession.SharedSession.UploadNote(myFancyNote, null);
+
+            // Delete the HTML content note we just created.
+            ENSession.SharedSession.DeleteNote(myFancyNoteRef);
+        }
+    }
+}

--- a/src/EvernoteSDK.Tests/ENSession_DownloadNotes.cs
+++ b/src/EvernoteSDK.Tests/ENSession_DownloadNotes.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Text;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace EvernoteSDK.Tests
+{
+    /// <summary>
+    /// Summary description for ENSession_DownloadNotes
+    /// </summary>
+    [TestClass]
+    public class ENSession_DownloadNotes
+    {
+        public ENSession_DownloadNotes()
+        {
+            //
+            // TODO: Add constructor logic here
+            //
+        }
+
+        private TestContext testContextInstance;
+
+        /// <summary>
+        ///Gets or sets the test context which provides
+        ///information about and functionality for the current test run.
+        ///</summary>
+        public TestContext TestContext
+        {
+            get
+            {
+                return testContextInstance;
+            }
+            set
+            {
+                testContextInstance = value;
+            }
+        }
+
+        #region Additional test attributes
+        //
+        // You can use the following additional attributes as you write your tests:
+        //
+        // Use ClassInitialize to run code before running the first test in the class
+        [ClassInitialize()]
+        public static void MyClassInitialize(TestContext testContext)
+        {
+            TestUtils.AuthenticateToEverNote();
+        }
+        //
+        // Use ClassCleanup to run code after all tests in a class have run
+        // [ClassCleanup()]
+        // public static void MyClassCleanup() { }
+        //
+        // Use TestInitialize to run code before running each test 
+        // [TestInitialize()]
+        // public void MyTestInitialize() { }
+        //
+        // Use TestCleanup to run code after each test has run
+        // [TestCleanup()]
+        // public void MyTestCleanup() { }
+        //
+        #endregion
+
+        [TestMethod]
+        public void WhenDownloadForAlreadyUploadedNote_ShouldDownloadCorrectNote()
+        {
+            string textToFind = Guid.NewGuid().ToString();
+            ENNote myPlainNote = new ENNote();
+            myPlainNote.Title = textToFind;
+            myPlainNote.Content = ENNoteContent.NoteContentWithString(textToFind);
+            ENSession.SharedSession.UploadNote(myPlainNote, null);
+
+            List<ENSessionFindNotesResult> myResultsList = ENSession.SharedSession.FindNotes(ENNoteSearch.NoteSearch(textToFind), null, ENSession.SearchScope.All, ENSession.SortOrder.RecentlyUpdated, 500);
+            bool contentDownloaded = false;
+            if (myResultsList.Count > 0)
+            {
+                // Given a NoteRef instance, download that note.
+                ENNote myDownloadedNote = ENSession.SharedSession.DownloadNote(myResultsList[0].NoteRef);
+                contentDownloaded= string.Equals(myDownloadedNote.TextContent, textToFind);
+            }
+            Assert.IsTrue(contentDownloaded, "Note able to download required note");
+        }
+    }
+}

--- a/src/EvernoteSDK.Tests/ENSession_FindNotes.cs
+++ b/src/EvernoteSDK.Tests/ENSession_FindNotes.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Text;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace EvernoteSDK.Tests
+{
+    /// <summary>
+    /// Summary description for ENSession_FindNotes
+    /// </summary>
+    [TestClass]
+    public class ENSession_FindNotes
+    {
+        public ENSession_FindNotes()
+        {
+            //
+            // TODO: Add constructor logic here
+            //
+        }
+
+        private TestContext testContextInstance;
+
+        /// <summary>
+        ///Gets or sets the test context which provides
+        ///information about and functionality for the current test run.
+        ///</summary>
+        public TestContext TestContext
+        {
+            get
+            {
+                return testContextInstance;
+            }
+            set
+            {
+                testContextInstance = value;
+            }
+        }
+
+        #region Additional test attributes
+        //
+        // You can use the following additional attributes as you write your tests:
+        
+        //Use ClassInitialize to run code before running the first test in the class
+         [ClassInitialize()]
+        public static void MyClassInitialize(TestContext testContext)
+        {
+            TestUtils.AuthenticateToEverNote();
+        }
+        //
+        // Use ClassCleanup to run code after all tests in a class have run
+        // [ClassCleanup()]
+        // public static void MyClassCleanup() { }
+        //
+        // Use TestInitialize to run code before running each test 
+        // [TestInitialize()]
+        // public void MyTestInitialize() { }
+        //
+        // Use TestCleanup to run code after each test has run
+        // [TestCleanup()]
+        // public void MyTestCleanup() { }
+        //
+        #endregion
+
+        [TestMethod]
+        public void WhenSearchForAlreadyUploadedNote_ShouldSucceed()
+        {
+            string textToFind = Guid.NewGuid().ToString();
+            ENNote myPlainNote = new ENNote();
+            myPlainNote.Title = textToFind;
+            myPlainNote.Content = ENNoteContent.NoteContentWithString(textToFind + "My plain text note");
+            ENSession.SharedSession.UploadNote(myPlainNote, null);
+
+            List<ENSessionFindNotesResult> myResultsList = ENSession.SharedSession.FindNotes(ENNoteSearch.NoteSearch(textToFind), null, ENSession.SearchScope.All, ENSession.SortOrder.RecentlyUpdated, 500);
+            int noteCount = 0;
+            if (myResultsList.Count > 0)
+            {
+                foreach (ENSessionFindNotesResult result in myResultsList)
+                {
+                    if(string.Equals( result.Title,textToFind)) {
+                        noteCount += 1;
+                    }
+                }
+            }
+            Assert.IsTrue(noteCount == 1, "Either search failed or returned more results.");
+        }
+    }
+}

--- a/src/EvernoteSDK.Tests/ENSession_ShareNote.cs
+++ b/src/EvernoteSDK.Tests/ENSession_ShareNote.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace EvernoteSDK.Tests
+{
+    [TestClass]
+    public class ENSession_ShareNote
+    {
+        [TestInitialize]
+        public void Initialize()
+        {
+            TestUtils.AuthenticateToEverNote();
+        }
+
+        [TestMethod]
+        public void WhenSharingSimpleNote_ShouldReturnSharedNoteUrl()
+        {
+            ENNote myPlainNote = new ENNote();
+            myPlainNote.Title = "My plain text note to share";
+            myPlainNote.Content = ENNoteContent.NoteContentWithString("Hello, world! I am sharing");
+            ENNoteRef myPlainNoteRef = ENSession.SharedSession.UploadNote(myPlainNote, null);
+
+            // Share this new note publicly.  "shareUrl" is the public URL to distribute to access the note.
+            string shareUrl = ENSession.SharedSession.ShareNote(myPlainNoteRef);
+            Assert.IsFalse(string.IsNullOrWhiteSpace(shareUrl), "Not able to obtain shared note url");
+        }
+    }
+}

--- a/src/EvernoteSDK.Tests/ENSession_UploadNote.cs
+++ b/src/EvernoteSDK.Tests/ENSession_UploadNote.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+namespace EvernoteSDK.Tests
+{
+    [TestClass]
+    public class ENSession_UploadNote
+    {
+        [TestInitialize]
+        public void Initialize()
+        {
+            TestUtils.AuthenticateToEverNote();
+        }
+        [TestMethod]
+        public void WhenContentIsSimpleText_ShouldSucceed()
+        {
+            // Get a list of all notebooks in the user's account.
+            List<ENNotebook> myNotebookList = ENSession.SharedSession.ListNotebooks();
+
+            // Create a new note (in the user's default notebook) with some plain text content.
+            ENNote myPlainNote = new ENNote();
+            myPlainNote.Title = "My plain text note";
+            myPlainNote.Content = ENNoteContent.NoteContentWithString("Hello, world!");
+            ENNoteRef myPlainNoteRef = ENSession.SharedSession.UploadNote(myPlainNote, null);
+        }
+        [TestMethod]
+        public void WhenContentIsHtml_ShouldSucceed()
+        {
+            // Create a new note (in the user's default notebook) with some HTML content.
+            ENNote myFancyNote = new ENNote();
+            myFancyNote.Title = "My first note";
+            myFancyNote.Content = ENNoteContent.NoteContentWithSanitizedHTML("<p>Hello, world - <i>this</i> is a <b>fancy</b> note - and here is a table:</p><br /> <br/><table border=\"1\" cellpadding=\"2\" cellspacing=\"0\" width=\"100%\"><tr><td>Red</td><td>Green</td></tr><tr><td>Blue</td><td>Yellow</td></tr></table>");
+            ENNoteRef myFancyNoteRef = ENSession.SharedSession.UploadNote(myFancyNote, null);
+        }
+        
+        [TestMethod]
+        public void WhenNoteContainsResource_ShouldSucceed()
+        {
+            // Create a new note with a resource.
+            ENNote myResourceNote = new ENNote();
+            myResourceNote.Title = "My test note with a resource";
+            myResourceNote.Content = ENNoteContent.NoteContentWithString("Hello, resource!");
+            byte[] myFile = TestUtils.StreamFile(TestConfiguration.PathToJPEGFile);
+            ENResource myResource = new ENResource(myFile, "image/jpg", "My First Picture.jpg");
+            myResourceNote.Resources.Add(myResource);
+            ENNoteRef myResourceRef = ENSession.SharedSession.UploadNote(myResourceNote, null);
+
+        }
+    }
+}

--- a/src/EvernoteSDK.Tests/EvernoteSDK.Tests.csproj
+++ b/src/EvernoteSDK.Tests/EvernoteSDK.Tests.csproj
@@ -1,0 +1,123 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{86794611-FE20-4267-95E7-4EF76FBB51FC}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>EvernoteSDK.Tests</RootNamespace>
+    <AssemblyName>EvernoteSDK.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="CsQuery">
+      <HintPath>..\..\assemblies\CsQuery.dll</HintPath>
+    </Reference>
+    <Reference Include="en-html2enml">
+      <HintPath>..\..\assemblies\en-html2enml.dll</HintPath>
+    </Reference>
+    <Reference Include="Evernote">
+      <HintPath>..\..\assemblies\Evernote.dll</HintPath>
+    </Reference>
+    <Reference Include="EvernoteOAuthNet">
+      <HintPath>..\..\assemblies\EvernoteOAuthNet.dll</HintPath>
+    </Reference>
+    <Reference Include="PreMailer.Net">
+      <HintPath>..\..\assemblies\PreMailer.Net.dll</HintPath>
+    </Reference>
+    <Reference Include="SgmlReaderDll">
+      <HintPath>..\..\assemblies\SgmlReaderDll.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core">
+      <RequiredTargetFramework>3.5</RequiredTargetFramework>
+    </Reference>
+    <Reference Include="Thrift">
+      <HintPath>..\..\assemblies\Thrift.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <Choose>
+    <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+  <ItemGroup>
+    <Compile Include="ENSession_DeleteNote.cs" />
+    <Compile Include="ENSession_DownloadNotes.cs" />
+    <Compile Include="ENSession_FindNotes.cs" />
+    <Compile Include="ENSession_ShareNote.cs" />
+    <Compile Include="TestConfiguration.cs" />
+    <Compile Include="ENSession_UploadNote.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TestMemoryBasedENPreferenceStore.cs" />
+    <Compile Include="TestUtils.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\EvernoteSDK\EvernoteSDK.csproj">
+      <Project>{efb2706a-ee60-4b33-abd4-695b509f277b}</Project>
+      <Name>EvernoteSDK</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.CodedUITestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Common, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Extension, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITesting, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/EvernoteSDK.Tests/Properties/AssemblyInfo.cs
+++ b/src/EvernoteSDK.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("EvernoteSDK.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("EvernoteSDK.Tests")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("86794611-fe20-4267-95e7-4ef76fbb51fc")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/EvernoteSDK.Tests/TestConfiguration.cs
+++ b/src/EvernoteSDK.Tests/TestConfiguration.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace EvernoteSDK.Tests
+{
+    class TestConfiguration
+    {
+        /// <summary>
+        /// If its true use ENSession.SetSharedSessionDeveloperToken("developer token", "note store url);
+        /// Else use ENSession.SetSharedSessionConsumerKey("your key", "your secret"); for authentication
+        /// </summary>
+        internal static bool ShouldUseDeveloperTokenToAuthenticate { get; }=true;
+        /// <summary>
+        /// Path and filename of a JPG file on your computer. Be sure to replace this with a real JPG file
+        /// </summary>
+        internal static string PathToJPEGFile { get; }= @"";
+
+        // Be sure to put your own development token here.
+        public static string DeveloperToken { get;  } = "your development token here";
+        public static string NoteStoreUrl { get;  } = "url to your note store";
+        // Be sure to put your own consumer key and consumer secret here.
+        public static string SessionConsumerKey { get; }= "your key";
+        public static string SessionConsumerSecret { get;  }= "your secret";
+    }
+}

--- a/src/EvernoteSDK.Tests/TestMemoryBasedENPreferenceStore.cs
+++ b/src/EvernoteSDK.Tests/TestMemoryBasedENPreferenceStore.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using EvernoteSDK.Advanced;
+
+namespace EvernoteSDK.Tests
+{
+    public class TestMemoryBasedENPreferenceStore: ENPreferencesStore
+    {
+        private Dictionary<string, object> _Store { get; set; }
+        public TestMemoryBasedENPreferenceStore()
+        {
+            _Store = new Dictionary<string, object>();
+        }
+        public override object ObjectForKey(string key)
+        {
+            object value = null;
+            _Store.TryGetValue(key, out value);
+            return value;
+        }
+        public override void RemoveAllObjects()
+        {
+            _Store.Clear();
+        }
+        public override void SetObject(object objectToStore, string key)
+        {
+            if (objectToStore != null)
+            {
+                _Store[key] = objectToStore;
+            }
+            else
+            {
+                _Store.Remove(key);
+            }
+        }
+    }
+}

--- a/src/EvernoteSDK.Tests/TestUtils.cs
+++ b/src/EvernoteSDK.Tests/TestUtils.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace EvernoteSDK.Tests
+{
+    internal class TestUtils
+    {
+
+        // Support routine for displaying a note thumbnail.
+        internal static byte[] StreamFile(string filename)
+        {
+            FileStream fs = new FileStream(filename, FileMode.Open, FileAccess.Read);
+
+            // Create a byte array of file stream length
+            byte[] ImageData = new byte[Convert.ToInt32(fs.Length - 1) + 1];
+
+            //Read block of bytes from stream into the byte array
+            fs.Read(ImageData, 0, System.Convert.ToInt32(fs.Length));
+
+            //Close the File Stream
+            fs.Close();
+            //return the byte data
+            return ImageData;
+        }
+
+        internal static void AuthenticateToEverNote()
+        {
+            if (TestConfiguration.ShouldUseDeveloperTokenToAuthenticate)
+            {
+                ENSession.SetSharedSessionDeveloperToken(TestConfiguration.DeveloperToken, TestConfiguration.NoteStoreUrl);
+            }
+            else
+            {
+                ENSession.SetSharedSessionConsumerKey(TestConfiguration.SessionConsumerKey, TestConfiguration.SessionConsumerSecret);
+            }
+
+            if (ENSession.SharedSession.IsAuthenticated == false)
+            {
+                ENSession.SharedSession.AuthenticateToEvernote();
+            }
+        }
+    }
+}

--- a/src/EvernoteSDK/Advanced/ENPreferencesStore.cs
+++ b/src/EvernoteSDK/Advanced/ENPreferencesStore.cs
@@ -10,7 +10,8 @@ namespace EvernoteSDK
 	{
 		public class ENPreferencesStore
 		{
-			private string Pathname {get; set;}
+            private const string ENSessionPreferencesFilename = "EvernoteSDKPrefs.bin";
+            private string Pathname {get; set;}
 			private Dictionary<string, object> Store {get; set;}
 
 			private static object PathnameForStoreFilename(string filename)
@@ -24,7 +25,9 @@ namespace EvernoteSDK
 				}
 				return string.Format("{0}\\{1}\\{2}\\{3}", Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), companyKey, productKey, filename);
 			}
-
+            public ENPreferencesStore() : this(ENSessionPreferencesFilename)
+            {
+            }
 			public ENPreferencesStore(string filename)
 			{
 				Pathname = PathnameForStoreFilename(filename).ToString();

--- a/src/EvernoteSDK/Advanced/ENPreferencesStore.cs
+++ b/src/EvernoteSDK/Advanced/ENPreferencesStore.cs
@@ -8,6 +8,9 @@ namespace EvernoteSDK
 {
 	namespace Advanced
 	{
+        /// <summary>
+        /// Preference store for Evernote SDK. 
+        /// </summary>
 		public class ENPreferencesStore
 		{
             private const string ENSessionPreferencesFilename = "EvernoteSDKPrefs.bin";
@@ -35,14 +38,14 @@ namespace EvernoteSDK
 				Load();
 			}
 
-			public object ObjectForKey(string key)
+			public virtual object ObjectForKey(string key)
 			{
 				object value = null;
 				Store.TryGetValue(key, out value);
 				return value;
 			}
 
-			public void SetObject(object objectToStore, string key)
+			public virtual void SetObject(object objectToStore, string key)
 			{
 				if (objectToStore != null)
 				{
@@ -69,7 +72,7 @@ namespace EvernoteSDK
                 stream.Close();
             }
 
-			public void RemoveAllObjects()
+			public virtual void RemoveAllObjects()
 			{
 				Store.Clear();
 				Save();

--- a/src/EvernoteSDK/Advanced/ENPreferencesStoreFactory.cs
+++ b/src/EvernoteSDK/Advanced/ENPreferencesStoreFactory.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using EvernoteSDK.Advanced.Utilities;
+using EvernoteSDK.Configuration;
+
+namespace EvernoteSDK.Advanced
+{
+    public class ENPreferencesStoreFactory
+    {
+        private static Lazy<ENPreferencesStore> _lazyInitializedPreferenceStore = new Lazy<ENPreferencesStore>(() =>
+         {
+             return ObjectFactory.CreateObject<ENPreferencesStore>(ENSDKConfiguration.Singleton.PreferencesStoreType);
+         });
+        public static ENPreferencesStore GetENPreferencesStore()
+        {
+            return _lazyInitializedPreferenceStore.Value;
+
+        }
+    }
+}

--- a/src/EvernoteSDK/Advanced/ENPreferencesStoreFactory.cs
+++ b/src/EvernoteSDK/Advanced/ENPreferencesStoreFactory.cs
@@ -11,7 +11,8 @@ namespace EvernoteSDK.Advanced
     {
         private static Lazy<ENPreferencesStore> _lazyInitializedPreferenceStore = new Lazy<ENPreferencesStore>(() =>
          {
-             return ObjectFactory.CreateObject<ENPreferencesStore>(ENSDKConfiguration.Singleton.PreferencesStoreType);
+             ENPreferencesStore store = ObjectFactory.CreateObject<ENPreferencesStore>(ENSDKConfiguration.Singleton.PreferencesStoreType);
+             return store;
          });
         public static ENPreferencesStore GetENPreferencesStore()
         {

--- a/src/EvernoteSDK/Advanced/Utilities/ObjectFactory.cs
+++ b/src/EvernoteSDK/Advanced/Utilities/ObjectFactory.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace EvernoteSDK.Advanced.Utilities
+{
+    internal class ObjectFactory
+    {
+        public static ObjectType CreateObject<ObjectType>(string fullyQualifiedTypeName)
+        {
+            ObjectType result = default(ObjectType);
+            Type requestedType = Type.GetType(fullyQualifiedTypeName);
+            result = Activator.CreateInstance<ObjectType>();
+            return result;
+        }
+    }
+}

--- a/src/EvernoteSDK/Advanced/Utilities/ObjectFactory.cs
+++ b/src/EvernoteSDK/Advanced/Utilities/ObjectFactory.cs
@@ -9,9 +9,9 @@ namespace EvernoteSDK.Advanced.Utilities
     {
         public static ObjectType CreateObject<ObjectType>(string fullyQualifiedTypeName)
         {
-            ObjectType result = default(ObjectType);
+            
             Type requestedType = Type.GetType(fullyQualifiedTypeName);
-            result = Activator.CreateInstance<ObjectType>();
+            ObjectType result = (ObjectType)Activator.CreateInstance(requestedType);
             return result;
         }
     }

--- a/src/EvernoteSDK/Configuration/ENSDKConfiguration.cs
+++ b/src/EvernoteSDK/Configuration/ENSDKConfiguration.cs
@@ -19,7 +19,6 @@ namespace EvernoteSDK.Configuration
             if (currentConfiguration == null)
             {
                 currentConfiguration = new ENSDKConfiguration();
-                currentConfiguration.InitializeDefault();
             }
             return currentConfiguration;
         }
@@ -35,11 +34,6 @@ namespace EvernoteSDK.Configuration
             {
                 this["preferencesStoreType"] = value;
             }
-        }
-        protected override void InitializeDefault()
-        {
-            base.InitializeDefault();
-            PreferencesStoreType = PreferencesStoreTypeDefault;
         }
     }
 }

--- a/src/EvernoteSDK/Configuration/ENSDKConfiguration.cs
+++ b/src/EvernoteSDK/Configuration/ENSDKConfiguration.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Configuration;
+using System.Linq;
+using System.Text;
+
+namespace EvernoteSDK.Configuration
+{
+    public class ENSDKConfiguration:ConfigurationSection
+    {
+        private static Lazy<ENSDKConfiguration> _lazyInitializedConfig = new Lazy<ENSDKConfiguration>(() => ConfigurationManager.GetSection("EvernoteSDK") as ENSDKConfiguration);
+
+        public static ENSDKConfiguration Singleton { get { return _lazyInitializedConfig.Value; } }
+        [ConfigurationProperty(name:"PreferencesStoreType",DefaultValue= "EvernoteSDK.Advanced.ENPreferencesStore,EvernoteSDK")]
+        public string PreferencesStoreType { get; set; }
+    }
+}

--- a/src/EvernoteSDK/Configuration/ENSDKConfiguration.cs
+++ b/src/EvernoteSDK/Configuration/ENSDKConfiguration.cs
@@ -6,12 +6,40 @@ using System.Text;
 
 namespace EvernoteSDK.Configuration
 {
-    public class ENSDKConfiguration:ConfigurationSection
+    public class ENSDKConfiguration : ConfigurationSection
     {
-        private static Lazy<ENSDKConfiguration> _lazyInitializedConfig = new Lazy<ENSDKConfiguration>(() => ConfigurationManager.GetSection("EvernoteSDK") as ENSDKConfiguration);
+        #region Constants
+        const string PreferencesStoreTypeDefault = "EvernoteSDK.Advanced.ENPreferencesStore,EvernoteSDK";
+        #endregion
 
+        private static Lazy<ENSDKConfiguration> _lazyInitializedConfig = new Lazy<ENSDKConfiguration>(() => GetFromConfigOrDefault());
+        private static ENSDKConfiguration GetFromConfigOrDefault()
+        {
+            ENSDKConfiguration currentConfiguration = ConfigurationManager.GetSection("EvernoteSDK") as ENSDKConfiguration;
+            if (currentConfiguration == null)
+            {
+                currentConfiguration = new ENSDKConfiguration();
+                currentConfiguration.InitializeDefault();
+            }
+            return currentConfiguration;
+        }
         public static ENSDKConfiguration Singleton { get { return _lazyInitializedConfig.Value; } }
-        [ConfigurationProperty(name:"PreferencesStoreType",DefaultValue= "EvernoteSDK.Advanced.ENPreferencesStore,EvernoteSDK")]
-        public string PreferencesStoreType { get; set; }
+        [ConfigurationProperty(name: "preferencesStoreType", DefaultValue = PreferencesStoreTypeDefault)]
+        public string PreferencesStoreType
+        {
+            get
+            {
+                return (string)this["preferencesStoreType"];
+            }
+            set
+            {
+                this["preferencesStoreType"] = value;
+            }
+        }
+        protected override void InitializeDefault()
+        {
+            base.InitializeDefault();
+            PreferencesStoreType = PreferencesStoreTypeDefault;
+        }
     }
 }

--- a/src/EvernoteSDK/ENSession.cs
+++ b/src/EvernoteSDK/ENSession.cs
@@ -354,7 +354,7 @@ namespace EvernoteSDK
 		public void Startup()
 		{
 			Logger = new ENSessionDefaultLogger();
-			_Preferences = new ENPreferencesStore(ENSessionPreferencesFilename);
+			_Preferences = ENPreferencesStoreFactory.GetENPreferencesStore();
 			AuthenticationCompleted = false;
 
 			SelectInitialSessionHost();

--- a/src/EvernoteSDK/ENSession.cs
+++ b/src/EvernoteSDK/ENSession.cs
@@ -20,7 +20,7 @@ namespace EvernoteSDK
 		private const string ENSessionBootstrapServerBaseURLStringCN = "app.yinxiang.com";
 		private const string ENSessionBootstrapServerBaseURLStringUS = "www.evernote.com";
 
-		private const string ENSessionPreferencesFilename = "EvernoteSDKPrefs.bin";
+		
 		private const string ENSessionPreferencesCredentialStore = "CredentialStore";
 		private const string ENSessionPreferencesCurrentProfileName = "CurrentProfileName";
 		private const string ENSessionPreferencesUser = "User";

--- a/src/EvernoteSDK/EvernoteSDK.csproj
+++ b/src/EvernoteSDK/EvernoteSDK.csproj
@@ -71,6 +71,7 @@
       <HintPath>Support Assemblies\SgmlReaderDll.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.configuration" />
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Runtime.Serialization" />
@@ -100,6 +101,7 @@
     <Compile Include="Advanced\EdamTag.cs" />
     <Compile Include="Advanced\ENNoteStoreClient.cs" />
     <Compile Include="Advanced\ENPreferencesStore.cs" />
+    <Compile Include="Advanced\ENPreferencesStoreFactory.cs" />
     <Compile Include="Advanced\ENSDKAdvanced.cs" />
     <Compile Include="Advanced\Utilities\CipherUtility.cs" />
     <Compile Include="Advanced\Utilities\ENMLWriter\ENMLWriterCOM.cs" />
@@ -110,7 +112,9 @@
     <Compile Include="Advanced\Utilities\ENMLWriter\ENEncryptedContentInfo.cs" />
     <Compile Include="Advanced\Utilities\ENMLWriter\ENMLWriter.cs" />
     <Compile Include="Advanced\Utilities\ENMLWriter\String_EDAMNullAdditions.cs" />
+    <Compile Include="Advanced\Utilities\ObjectFactory.cs" />
     <Compile Include="Advanced\Utilities\TimeConversions_EvernoteSDK.cs" />
+    <Compile Include="Configuration\ENSDKConfiguration.cs" />
     <Compile Include="ENNoteContentForCOM.cs" />
     <Compile Include="ENNoteSearchForCOM.cs">
       <SubType>Code</SubType>

--- a/src/EvernoteSDK/EvernoteSDK.xml
+++ b/src/EvernoteSDK/EvernoteSDK.xml
@@ -226,13 +226,18 @@
         <member name="M:EvernoteSDK.Advanced.ENNoteStoreClient.SetSharedNotebookRecipientSettings(System.Int64,Evernote.EDAM.Type.SharedNotebookRecipientSettings)">
             ** Set shared notebook recipient settings.
         </member>
-        <member name="M:EvernoteSDK.ENSession.SetSharedSessionConsumerKey(System.String,System.String,System.String)">
+        <member name="T:EvernoteSDK.Advanced.ENPreferencesStore">
+            <summary>
+            Preference store for Evernote 
+            </summary>
+        </member>
+        <member name="P:EvernoteSDK.Advanced.ENSessionAdvanced.SharedSession">
             **
         </member>
-        <member name="M:EvernoteSDK.ENSession.SetSharedSessionDeveloperToken(System.String,System.String)">
+        <member name="P:EvernoteSDK.Advanced.ENSessionAdvanced.PrimaryNoteStore">
             **
         </member>
-        <member name="F:EvernoteSDK.ENSession._sharedSession">
+        <member name="P:EvernoteSDK.Advanced.ENSessionAdvanced.BusinessNoteStore">
             **
         </member>
         <member name="M:EvernoteSDK.Advanced.ENSessionAdvanced.NoteStoreForLinkedNotebook(Evernote.EDAM.Type.LinkedNotebook)">
@@ -242,15 +247,6 @@
             **
         </member>
         <member name="M:EvernoteSDK.Advanced.ENSessionAdvanced.NoteStoreforNotebook(EvernoteSDK.ENNotebook)">
-            **
-        </member>
-        <member name="P:EvernoteSDK.Advanced.ENSessionAdvanced.SharedSession">
-            **
-        </member>
-        <member name="P:EvernoteSDK.Advanced.ENSessionAdvanced.PrimaryNoteStore">
-            **
-        </member>
-        <member name="P:EvernoteSDK.Advanced.ENSessionAdvanced.BusinessNoteStore">
             **
         </member>
         <member name="P:EvernoteSDK.Advanced.ENSessionFindNotesResultAdvanced.UpdateSequenceNumber">
@@ -534,6 +530,15 @@
             <param name="innerException">The exception that is the cause of the
             current exception, or a null reference if no inner exception is
             specified</param>
+        </member>
+        <member name="M:EvernoteSDK.ENSession.SetSharedSessionConsumerKey(System.String,System.String,System.String)">
+            **
+        </member>
+        <member name="M:EvernoteSDK.ENSession.SetSharedSessionDeveloperToken(System.String,System.String)">
+            **
+        </member>
+        <member name="F:EvernoteSDK.ENSession._sharedSession">
+            **
         </member>
         <member name="T:EvernoteSDK.Properties.Resources">
             <summary>

--- a/src/EvernoteSDK/EvernoteSDK.xml
+++ b/src/EvernoteSDK/EvernoteSDK.xml
@@ -228,7 +228,7 @@
         </member>
         <member name="T:EvernoteSDK.Advanced.ENPreferencesStore">
             <summary>
-            Preference store for Evernote 
+            Preference store for Evernote SDK. 
             </summary>
         </member>
         <member name="P:EvernoteSDK.Advanced.ENSessionAdvanced.SharedSession">


### PR DESCRIPTION
Configured the ENPreferencesStore object creation via .Net config.This will allow to host SDK in web servers which don't permit file system access. Default ENPreferencesStore is keeping cached values in  EvernoteSDKPrefs.bin.
