### PR TITLE
Fix bug when getting HTML or text content of a note

### DIFF
--- a/src/EvernoteSDK/Private/ENMLtoHTMLConverter.cs
+++ b/src/EvernoteSDK/Private/ENMLtoHTMLConverter.cs
@@ -15,6 +15,8 @@ internal class ENMLtoHTMLConverter
         {
             const string tagEnd = "/>";
             int tagEndLength = tagEnd.Length;
+            const string tagEndMediaAlternative = "/en-media>";            
+            int tagEndAlternativeLength = tagEndMediaAlternative.Length;
             contentResult = content.Replace("\"", "'");
             contentResult = contentResult.Replace(Microsoft.VisualBasic.Strings.Chr(13).ToString(), " ");
             contentResult = contentResult.Replace(Microsoft.VisualBasic.Strings.Chr(10).ToString(), " ");
@@ -26,11 +28,12 @@ internal class ENMLtoHTMLConverter
             while (mediaTagStart > 0)
             {
                 int mediaTagEnd = contentResult.IndexOf(tagEnd, mediaTagStart);
-                int mediaEndLength = 2;
-                if (!(mediaTagEnd > 0))
+                int mediaTagEndAlternative = contentResult.IndexOf(tagEndMediaAlternative, mediaTagStart);
+                int mediaEndLength = tagEndLength;
+                if (mediaTagEnd == -1 || (mediaTagEndAlternative != -1 && mediaTagEndAlternative < mediaTagEnd))
                 {
-                    mediaTagEnd = contentResult.IndexOf("/en-media>", mediaTagStart);
-                    mediaEndLength = 10;
+                    mediaTagEnd = mediaTagEndAlternative;
+                    mediaEndLength = tagEndAlternativeLength;
                 }
                 string mediaString = contentResult.Substring(mediaTagStart, (mediaTagEnd - mediaTagStart) + mediaEndLength);
                 if (mediaString.IndexOf("type='image/") > 0)


### PR DESCRIPTION
When you read the HtmlContent or TextContent property of ENNote or ENNoteAdvanced then it is sometimes cut shorter than it should be, sometimes very short. This happens if the note contains any resources such as images (en-media tags in ENML), which are inline so that more text follows an image and there might be another image embedded in the content and so on. The current implementation returns the text up to the first image and cuts out the rest. Actually, what content gets left out depends exactly where the images are and if there are any BR tags and so on, but that's the gist of it. 
**Technical implementation details:**
It seems the root cause of this bug is the fact that there is not one way to close the en-media tag, which is `<en-media ... />`, but two ways - there is also `<en-media ...></en-media>` and the current implementation only deals with the first case. The commit within this pull request deals with both cases. 